### PR TITLE
add die_with, which can run a function when dying

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ None.die("none option"); // prints `none option` to stderr then exits with code 
 Err("failure").die_code("strange error", 4); // prints `strange error` to stderr then exits with code 4
 None.die_code("none option", 5); // prints `none option` to stderr then exits with code 5
 
+// with function (Result only):
+Err("failure").die_with(|error| format!("strange error: {}", error)); // prints `strange error: failure` to stderr then exits with code 1
+Err("failure").die_with(|error| (format!("strange error: {}", error), 6)); // prints `strange error: failure` to stderr then exits with code 6
+
 // die! macro:
 die!("argument to -e must be numeric"); // prints message to stderr then exits with code 1
 die!(2; "argument to -e must be numeric"); // prints message to stderr then exits with code 2

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,7 +100,7 @@ macro_rules! die {
 ///
 /// [`Result`]: https://doc.rust-lang.org/std/result/enum.Result.html
 /// [`Option`]: https://doc.rust-lang.org/std/option/enum.Option.html
-pub trait Die<T> {
+pub trait Die<T, E> {
     /// Unwraps a [`Result`] or [`Option`], yielding the content of an [`Ok`] or [`Some`].
     ///
     /// # Exits
@@ -164,9 +164,11 @@ pub trait Die<T> {
     /// x.die_code("strange", 3); // prints `strange` to stderr then exits with code 3
     /// ```
     fn die_code(self, msg: &str, exit_code: i32) -> T;
+
+    fn die_with<X: PrintExit>(self, func: fn(E) -> X) -> T;
 }
 
-impl<T, E> Die<T> for Result<T, E> {
+impl<T, E> Die<T, E> for Result<T, E> {
     #[inline]
     fn die(self, msg: &str) -> T {
         self.die_code(msg, DEFAULT_EXIT_CODE)
@@ -178,9 +180,16 @@ impl<T, E> Die<T> for Result<T, E> {
             Err(_) => PrintExit::print_exit(&(exit_code, msg)),
         }
     }
+
+    fn die_with<X: PrintExit>(self, func: fn(E) -> X) -> T {
+        match self {
+            Ok(t) => t,
+            Err(err) => PrintExit::print_exit(&func(err))
+        }
+    }
 }
 
-impl<T> Die<T> for Option<T> {
+impl<T> Die<T, ()> for Option<T> {
     #[inline]
     fn die(self, msg: &str) -> T {
         self.die_code(msg, DEFAULT_EXIT_CODE)
@@ -190,6 +199,13 @@ impl<T> Die<T> for Option<T> {
         match self {
             Some(t) => t,
             None => PrintExit::print_exit(&(exit_code, msg)),
+        }
+    }
+
+    fn die_with<X: PrintExit>(self, func: fn(()) -> X) -> T {
+        match self {
+            Some(t) => t,
+            None => PrintExit::print_exit(&func(()))
         }
     }
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -18,3 +18,10 @@ fn die_with_code_first() {
 fn die_empty() {
     die!();
 }
+
+#[test]
+#[should_panic]
+fn die_with_capture() {
+    let code = 3;
+    Result::<(), &str>::Err("error text").die_with(|error| (format!("Error is: {}", error), code));
+}


### PR DESCRIPTION
I'm pretty new to Rust so my apologies if my code isn't great. I added this for a project I'm working on. The main benefit is that with with Result types, you can include the error in your exit message. Here's how I use it in my codebase:

```rs
let conf = config::load_config(&opts)
    .die_with(|error| format!("Failed to read config file: {}", error));
```

It's also pretty easy to return an error code with this:

```rs
let conf = config::load_config(&opts)
    .die_with(|error| (format!("Failed to read config file: {}", error), 3));
```